### PR TITLE
Resolve issue with double Participant objects

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddParticipantToEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddParticipantToEventCommand.java
@@ -77,7 +77,6 @@ public class AddParticipantToEventCommand extends Command {
             throw new CommandException("Participant " + participantToAdd.getFullName() + " already exists!");
         }
 
-        // add participant
         selectedEvent.addParticipant(participantToAdd);
 
         return new CommandResult(String.format(MESSAGE_ADD_PARTICIPANT_TO_EVENT_SUCCESS,

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -41,7 +41,7 @@ public class DeleteCommand extends Command {
 
         Participant participantToDelete = lastShownList.get(targetIndex.getZeroBased());
         model.deleteParticipant(participantToDelete);
-        participantToDelete.deletefromEvents();
+        participantToDelete.deleteFromEvents();
         return new CommandResult(String.format(MESSAGE_DELETE_PARTICIPANT_SUCCESS, participantToDelete));
     }
 

--- a/src/main/java/seedu/address/logic/commands/RemoveParticipantFromEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RemoveParticipantFromEventCommand.java
@@ -76,7 +76,6 @@ public class RemoveParticipantFromEventCommand extends Command {
                     String.format(MESSAGE_PARTICIPANT_NOT_IN_EVENT, participantToRemove.getFullName()));
         }
 
-        // add participant
         selectedEvent.removeParticipant(participantToRemove);
 
         return new CommandResult(String.format(MESSAGE_ADD_PARTICIPANT_TO_EVENT_SUCCESS,

--- a/src/main/java/seedu/address/model/participant/Participant.java
+++ b/src/main/java/seedu/address/model/participant/Participant.java
@@ -213,6 +213,15 @@ public class Participant {
     }
 
     /**
+     * Returns a string representation of the Participant's id.
+     *
+     * @return the Participant's id.
+     */
+    public String getIdValue() {
+        return this.id.toString();
+    }
+
+    /**
      * Returns true if both participants have the same name.
      * This defines a weaker notion of equality between two participants.
      * This allow Participant to both pass in Person and Participant objects.
@@ -227,7 +236,7 @@ public class Participant {
                 && otherParticipant.getBirthDate().equals(getBirthDate());
     }
 
-    public void deletefromEvents() {
+    public void deleteFromEvents() {
         this.events.forEach(e -> e.removeParticipant(this));
     }
 

--- a/src/main/java/seedu/address/storage/JsonAdaptedEvent.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedEvent.java
@@ -63,14 +63,7 @@ public class JsonAdaptedEvent {
      * @return an Event instance representing the JsonAdaptedEvent.
      * @throws IllegalValueException if there were any data constraints violated in the adapted event.
      */
-    public Event toModelType(List<JsonAdaptedParticipant> allParticipants) throws IllegalValueException {
-        final List<Participant> participants = new ArrayList<>();
-        // TODO: Optimise querying by using different data structures and algorithm in future updates
-        for (String participantId : participantIds) {
-            JsonAdaptedParticipant toAddParticipantJson =
-                    allParticipants.stream().filter(p -> p.getId().equals(participantId)).findFirst().get();
-            participants.add(toAddParticipantJson.toModelType());
-        }
+    public Event toModelType(List<Participant> allParticipants) throws IllegalValueException {
 
         if (this.name == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
@@ -106,6 +99,13 @@ public class JsonAdaptedEvent {
 
         boolean isDone = this.isDone.equals(Event.COMPLETED);
 
-        return new Event(eventName, eventDate, eventTime, isDone, participants);
+        final Event eventModel = new Event(eventName, eventDate, eventTime, isDone, new ArrayList<>());
+
+        // TODO: Optimise querying by using different data structures and algorithm in future updates
+        for (String participantId : participantIds) {
+            allParticipants.stream().filter(p -> p.getIdValue().equals(participantId))
+                    .findFirst().ifPresent(eventModel::addParticipant);
+        }
+        return eventModel;
     }
 }

--- a/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
+++ b/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
@@ -58,26 +58,23 @@ class JsonSerializableAddressBook {
      */
     public AddressBook toModelType() throws IllegalValueException {
         AddressBook addressBook = new AddressBook();
-        //Add on for Managera
-        for (JsonAdaptedEvent jsonAdaptedEvent : events) {
-            Event event = jsonAdaptedEvent.toModelType(participants);
-            if (addressBook.hasEvent(event)) {
-                throw new IllegalValueException(MESSAGE_DUPLICATE_EVENT);
-            }
-            addressBook.addEvent(event);
-        }
-
-        List<Event> eventList = addressBook.getEventList();
-
         // Changed for Managera
         for (JsonAdaptedParticipant jsonAdaptedParticipant : participants) {
             Participant participant = jsonAdaptedParticipant.toModelType();
             if (addressBook.hasParticipant(participant)) {
                 throw new IllegalValueException(MESSAGE_DUPLICATE_PARTICIPANT);
             }
-
-            eventList.stream().filter(e -> e.hasParticipant(participant)).forEach(participant::addEvent);
             addressBook.addParticipant(participant);
+        }
+        List<Participant> participantList = addressBook.getParticipantList();
+
+        //Add on for Managera
+        for (JsonAdaptedEvent jsonAdaptedEvent : events) {
+            Event event = jsonAdaptedEvent.toModelType(participantList);
+            if (addressBook.hasEvent(event)) {
+                throw new IllegalValueException(MESSAGE_DUPLICATE_EVENT);
+            }
+            addressBook.addEvent(event);
         }
 
         return addressBook;

--- a/src/test/java/seedu/address/storage/JsonAdaptedEventTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedEventTest.java
@@ -31,7 +31,7 @@ public class JsonAdaptedEventTest {
     private static final List<String> VALID_PARTICIPANT_IDS = SAMPLE_EVENT.getParticipants().stream()
             .map(Participant::getParticipantId).map(ParticipantId::toString)
             .collect(Collectors.toList());
-    private static final List<JsonAdaptedParticipant> participants = List.of();
+    private static final List<Participant> participants = List.of();
 
     @Test
     public void toModelType_validEventDetails_returnsEvent() throws Exception {


### PR DESCRIPTION
Upon startup, Managera would create up to two instances of each Participant. One instance is added into addressbook, and the other is added into the Participant list of any Event the Participant is attending. This is due to an outdated method of deserialising the Participant and Event objects from the save file.

This causes unnecessary usage of extra memory to store the extra Participant objects.

Let's adjust the way that Managera deserialises the Participant and Event objects from the save file so that only one Participant object is ever created for each Participant.