### PR TITLE
Fix UI bug for events not updating participants

### DIFF
--- a/src/main/java/seedu/address/model/event/Event.java
+++ b/src/main/java/seedu/address/model/event/Event.java
@@ -2,10 +2,11 @@ package seedu.address.model.event;
 
 import static java.util.Objects.requireNonNull;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
 import seedu.address.model.participant.Participant;
 
 /**
@@ -16,7 +17,7 @@ public class Event implements Comparable<Event> {
     public static final String COMPLETED = "Completed";
     public static final String UNCOMPLETED = "Uncompleted";
     private boolean isDone;
-    private ArrayList<Participant> participants = new ArrayList<>();
+    private ObservableList<Participant> participants = FXCollections.observableArrayList();
     private EventName eventName;
     private EventDate eventDate;
     private EventTime eventTime;
@@ -91,7 +92,7 @@ public class Event implements Comparable<Event> {
         return isDone;
     }
 
-    public List<Participant> getParticipants() {
+    public ObservableList<Participant> getParticipants() {
         return participants;
     }
 

--- a/src/main/java/seedu/address/model/event/UniqueEventList.java
+++ b/src/main/java/seedu/address/model/event/UniqueEventList.java
@@ -3,10 +3,12 @@ package seedu.address.model.event;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 
+import javafx.beans.Observable;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import seedu.address.model.event.exceptions.DuplicateEventException;
@@ -24,7 +26,8 @@ import seedu.address.model.event.exceptions.EventNotFoundException;
  * @see Event#isSameEvent(Event)
  */
 public class UniqueEventList implements Iterable<Event> {
-    private final ObservableList<Event> internalList = FXCollections.observableArrayList();
+    private final ObservableList<Event> internalList =
+            FXCollections.observableList(new ArrayList<>(), (Event e) -> new Observable[]{e.getParticipants()});
     private final ObservableList<Event> internalUnmodifiableList =
             FXCollections.unmodifiableObservableList(internalList);
 


### PR DESCRIPTION
When Participants are added to or removed from an Event, the Event in the Event list of Managera does not update its list of Participants correctly. This is due to how ObservableList works, which listens to changes in the objects in the list, but not when the attributes of the objects are changed.

Let's change the list of Participants in Events from an ArrayList to an ObservableList, and include a callback in UniqueEventList to listen for any changes made to this ObservableList in the Event. That way, when a Participant is removed from or added to an Event, it would invoke the callback method and cause javaFX to update the UI accordingly.