### PR TITLE
Branch error handling update v1.4

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -22,23 +22,25 @@ public class Messages {
             "Event %1$s Not Found, consider relisting events using '%2$s'";
 
     /**
-     * Forms the message that states that a Participant already exists in an Event in Managera.
-     *
-     * @param participantName The name of the Participant.
-     * @return a message that states that the Participant already exists in an Event.
-     */
-    public static String showParticipantExists(String participantName) {
-        return "Participant " + participantName + " already exists!";
-    }
-
-    /**
      * Forms the message that states that a Participant does not exist in an Event in Managera.
      *
      * @param participantName The name of the Participant.
+     * @param eventName       The name of the Event.
      * @return a message that states that the Participant does not exist in an Event.
      */
-    public static String showParticipantDoesNotExist(String participantName) {
-        return "Participant " + participantName + " doesn't exist in this event!";
+    public static String showParticipantDoesNotExist(String participantName, String eventName) {
+        return String.format("%s is not taking part in %s!", participantName, eventName);
+    }
+
+    /**
+     * Forms the message that indicates a participant is already enrolled in an Event in Managera.
+     *
+     * @param participantName  The name of the Participant.
+     * @param eventName        The name of the Event.
+     * @return a message that states that the participant is already in the given event.
+     */
+    public static String showParticipantAlreadyEnrolled(String participantName, String eventName) {
+        return String.format("%s is already enrolled into %s!", participantName, eventName);
     }
 
     /**

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -20,7 +20,7 @@ public class AddCommand extends Command {
 
     public static final String COMMAND_WORD = "add";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a participant to the address book. "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a participant to Managera. "
             + "Parameters: "
             + PREFIX_NAME + "NAME "
             + PREFIX_PHONE + "PHONE "
@@ -34,7 +34,7 @@ public class AddCommand extends Command {
             + PREFIX_ADDRESS + "311, Clementi Ave 2, #02-25 ";
 
     public static final String MESSAGE_SUCCESS = "Added participant:\n%1$s";
-    public static final String MESSAGE_DUPLICATE_PARTICIPANT = "This participant already exists in the address book";
+    public static final String MESSAGE_DUPLICATE_PARTICIPANT = "This participant already exists in Managera";
 
     private final Participant toAdd;
 

--- a/src/main/java/seedu/address/logic/commands/AddNextOfKinCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddNextOfKinCommand.java
@@ -20,6 +20,7 @@ public class AddNextOfKinCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a next-of-kin to a participant with specified "
             + "index.\n"
+            + "Index should be positive integer.\n"
             + "Parameters: "
             + "PARTICIPANT_INDEX "
             + PREFIX_NAME + "NAME "

--- a/src/main/java/seedu/address/logic/commands/AddParticipantToEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddParticipantToEventCommand.java
@@ -17,7 +17,7 @@ public class AddParticipantToEventCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Adds Participant with specified index to an event with another specified index.\n"
-            + "Index should be positive integer.\n"
+            + "Indexes should be positive integers.\n"
             + "Parameters: "
             + "PARTICIPANT_INDEX "
             + "EVENT_INDEX\n"

--- a/src/main/java/seedu/address/logic/commands/AddParticipantToEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddParticipantToEventCommand.java
@@ -17,6 +17,7 @@ public class AddParticipantToEventCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Adds Participant with specified index to an event with another specified index.\n"
+            + "Index should be positive integer.\n"
             + "Parameters: "
             + "PARTICIPANT_INDEX "
             + "EVENT_INDEX\n"

--- a/src/main/java/seedu/address/logic/commands/AddParticipantToEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddParticipantToEventCommand.java
@@ -60,7 +60,8 @@ public class AddParticipantToEventCommand extends Command {
         }
 
         if (selectedEvent.hasParticipant(participantToAdd)) {
-            throw new CommandException(Messages.showParticipantExists(participantToAdd.getFullName()));
+            throw new CommandException(Messages.showParticipantAlreadyEnrolled(
+                    participantToAdd.getFullName(), selectedEvent.getNameString()));
         }
 
         // add participant

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -19,7 +19,8 @@ public class DeleteCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Deletes the participant identified by the index number used in the displayed participant list.\n"
-            + "Parameters: INDEX (must be a positive integer)\n"
+            + "Index should be positive integer.\n"
+            + "Parameters: INDEX\n"
             + "Example: " + COMMAND_WORD + " 1";
 
     public static final String MESSAGE_DELETE_PARTICIPANT_SUCCESS = "Deleted participant:\n%1$s";

--- a/src/main/java/seedu/address/logic/commands/DeleteEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteEventCommand.java
@@ -19,7 +19,8 @@ public class DeleteEventCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Deletes the event identified by the "
             + "index number used in the displayed event list as done.\n"
-            + "Parameters: INDEX (must be a positive integer)\n"
+            + "Index should be positive integer.\n"
+            + "Parameters: INDEX\n"
             + "Example: " + COMMAND_WORD + " 1";
 
     public static final String MESSAGE_DELETE_EVENT_SUCCESS = "Deleted event:\n%1$s";

--- a/src/main/java/seedu/address/logic/commands/DeleteNextOfKinCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteNextOfKinCommand.java
@@ -17,6 +17,7 @@ public class DeleteNextOfKinCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Deletes the next-of-kin with specified index from a "
             + "participant with another specified index.\n"
+            + "Index should be positive integer.\n"
             + "Parameters: \n"
             + "NOK_INDEX "
             + "PARTICIPANT_INDEX\n"

--- a/src/main/java/seedu/address/logic/commands/DeleteNextOfKinCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteNextOfKinCommand.java
@@ -17,7 +17,7 @@ public class DeleteNextOfKinCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Deletes the next-of-kin with specified index from a "
             + "participant with another specified index.\n"
-            + "Index should be positive integer.\n"
+            + "Indexes should be positive integers.\n"
             + "Parameters: \n"
             + "NOK_INDEX "
             + "PARTICIPANT_INDEX\n"

--- a/src/main/java/seedu/address/logic/commands/DoneCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DoneCommand.java
@@ -19,7 +19,8 @@ public class DoneCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Marks the event identified by the "
             + "index number used in the displayed event list as done.\n"
-            + "Parameters: INDEX (must be a positive integer)\n"
+            + "Index should be positive integer.\n"
+            + "Parameters: INDEX\n"
             + "Example: " + COMMAND_WORD + " 1";
 
     public static final String MESSAGE_DONE_EVENT_SUCCESS = "Marked event as done:\n%1$s";

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -35,8 +35,9 @@ public class EditCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the participant identified "
             + "by the index number used in the displayed participant list. "
+            + "Index should be positive integer.\n"
             + "Existing values will be overwritten by the input values.\n"
-            + "Parameters: INDEX (must be a positive integer) "
+            + "Parameters: INDEX "
             + "[" + PREFIX_NAME + "NAME] "
             + "[" + PREFIX_PHONE + "PHONE] "
             + "[" + PREFIX_EMAIL + "EMAIL] "

--- a/src/main/java/seedu/address/logic/commands/EditEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditEventCommand.java
@@ -26,8 +26,9 @@ public class EditEventCommand extends Command {
     public static final String COMMAND_WORD = "editEvent";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the event with specified index. "
+            + "Index should be positive integer.\n"
             + "Existing details will be overwritten by the new input details.\n"
-            + "Parameters: INDEX (must be a positive integer) "
+            + "Parameters: INDEX "
             + "[" + PREFIX_NAME + "NAME] "
             + "[" + PREFIX_DATE + "DATE] "
             + "[" + PREFIX_TIME + "TIME]\n"

--- a/src/main/java/seedu/address/logic/commands/RemoveParticipantFromEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RemoveParticipantFromEventCommand.java
@@ -61,7 +61,8 @@ public class RemoveParticipantFromEventCommand extends Command {
         }
 
         if (!selectedEvent.hasParticipant(participantToRemove)) {
-            throw new CommandException(Messages.showParticipantDoesNotExist(participantToRemove.getFullName()));
+            throw new CommandException(Messages.showParticipantDoesNotExist(
+                    participantToRemove.getFullName(), selectedEvent.getNameString()));
         }
 
         // remove participant

--- a/src/main/java/seedu/address/logic/commands/RemoveParticipantFromEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RemoveParticipantFromEventCommand.java
@@ -17,6 +17,7 @@ public class RemoveParticipantFromEventCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Removes the Participant with specified index from an event with another specified index.\n"
+            + "Index should be positive integer.\n"
             + "Parameters: "
             + "PARTICIPANT_INDEX "
             + "EVENT_INDEX\n"

--- a/src/main/java/seedu/address/logic/commands/ShowEventDetailsCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ShowEventDetailsCommand.java
@@ -19,6 +19,7 @@ public class ShowEventDetailsCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Displays the details of the event at the specified index.\n"
+            + "Index should be positive integer.\n"
             + "Parameters: INDEX \n"
             + "Example: " + COMMAND_WORD + " 1 ";
 

--- a/src/main/java/seedu/address/logic/commands/ShowEventParticipantsCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ShowEventParticipantsCommand.java
@@ -23,6 +23,7 @@ public class ShowEventParticipantsCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Displays a list of participants of the event at the specified index.\n"
+            + "Index should be positive integer.\n"
             + "Parameters: INDEX\n"
             + "Example: " + COMMAND_WORD + " 1";
 

--- a/src/main/java/seedu/address/logic/commands/ViewCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewCommand.java
@@ -19,7 +19,8 @@ public class ViewCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds the participant identified by the "
             + "index number used in the displayed participant list and displays the participant's details.\n"
-            + "Parameters: INDEX (must be a positive integer)\n"
+            + "Index should be positive integer.\n"
+            + "Parameters: INDEX\n"
             + "Example: " + COMMAND_WORD + " 1";
 
     private final Index targetIndex;

--- a/src/main/java/seedu/address/logic/parser/AddNextOfKinParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddNextOfKinParser.java
@@ -1,7 +1,6 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.commons.core.Messages.MESSAGE_INVALID_ZERO_BASED_INDEX;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
@@ -28,12 +27,7 @@ public class AddNextOfKinParser implements Parser<AddNextOfKinCommand> {
                     MESSAGE_INVALID_COMMAND_FORMAT, AddNextOfKinCommand.MESSAGE_USAGE));
         }
 
-        Index participantIndex;
-        try {
-            participantIndex = ParserUtil.parseIndex(sections[1]);
-        } catch (ParseException pe) {
-            throw new ParseException(MESSAGE_INVALID_ZERO_BASED_INDEX);
-        }
+        Index participantIndex = ParserUtil.parseIndex(sections[1]);
 
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args,
                 PREFIX_NAME, PREFIX_PHONE, PREFIX_TAG);

--- a/src/main/java/seedu/address/logic/parser/AddParticipantToEventParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddParticipantToEventParser.java
@@ -1,7 +1,6 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.commons.core.Messages.MESSAGE_INVALID_ZERO_BASED_INDEX;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.AddParticipantToEventCommand;
@@ -18,13 +17,8 @@ public class AddParticipantToEventParser implements Parser<AddParticipantToEvent
                     MESSAGE_INVALID_COMMAND_FORMAT, AddParticipantToEventCommand.MESSAGE_USAGE));
         }
 
-        try {
-            Index participantIndex = ParserUtil.parseIndex(sections[1]);
-            Index eventIndex = ParserUtil.parseIndex(sections[2]);
-            return new AddParticipantToEventCommand(participantIndex, eventIndex);
-        } catch (ParseException pe) {
-            throw new ParseException(MESSAGE_INVALID_ZERO_BASED_INDEX);
-        }
-
+        Index participantIndex = ParserUtil.parseIndex(sections[1]);
+        Index eventIndex = ParserUtil.parseIndex(sections[2]);
+        return new AddParticipantToEventCommand(participantIndex, eventIndex);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/DeleteNextOfKinParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteNextOfKinParser.java
@@ -1,7 +1,6 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.commons.core.Messages.MESSAGE_INVALID_ZERO_BASED_INDEX;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.DeleteNextOfKinCommand;
@@ -17,13 +16,8 @@ public class DeleteNextOfKinParser implements Parser<DeleteNextOfKinCommand> {
                     MESSAGE_INVALID_COMMAND_FORMAT, DeleteNextOfKinCommand.MESSAGE_USAGE));
         }
 
-        try {
-            Index nokIndex = ParserUtil.parseIndex(sections[1]);
-            Index participantIndex = ParserUtil.parseIndex(sections[2]);
-            return new DeleteNextOfKinCommand(nokIndex, participantIndex);
-        } catch (ParseException pe) {
-            throw new ParseException(MESSAGE_INVALID_ZERO_BASED_INDEX);
-        }
-
+        Index nokIndex = ParserUtil.parseIndex(sections[1]);
+        Index participantIndex = ParserUtil.parseIndex(sections[2]);
+        return new DeleteNextOfKinCommand(nokIndex, participantIndex);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -138,6 +138,10 @@ public class ParserUtil {
         String trimmedBirthDate = birthDate.trim();
         if (trimmedBirthDate.equals("N/A")) {
             return BirthDate.notSpecified();
+        } else if (!BirthDate.checkDateComponents(trimmedBirthDate)) {
+            throw new ParseException(BirthDate.MESSAGE_DATE_FORMAT_ERROR);
+        } else if (!BirthDate.isValidDate(trimmedBirthDate)) {
+            throw new ParseException(BirthDate.MESSAGE_DATE_DOES_NOT_EXIST);
         } else if (!BirthDate.isValidBirthDate(trimmedBirthDate)) {
             throw new ParseException(BirthDate.MESSAGE_DATE_CONSTRAINTS);
         }
@@ -149,7 +153,6 @@ public class ParserUtil {
      */
     public static NextOfKin parseNextOfKin(String nextOfKin) throws ParseException {
         requireNonNull(nextOfKin);
-        // TODO: IMPLEMENT THIS
         return new NextOfKin(new Name("Test"), new Phone("12345678"), new Tag("Test"));
     }
 
@@ -183,7 +186,9 @@ public class ParserUtil {
     public static EventDate parseEventDate(String eventDate) throws ParseException {
         requireNonNull(eventDate);
         String trimmedEventDate = eventDate.trim();
-        if (!EventDate.isValidDate(trimmedEventDate)) {
+        if (!EventDate.checkDateComponents(trimmedEventDate)) {
+            throw new ParseException(EventDate.MESSAGE_DATE_FORMAT_ERROR);
+        } else if (!EventDate.isValidDate(trimmedEventDate)) {
             throw new ParseException(EventDate.MESSAGE_CONSTRAINTS);
         }
         return new EventDate(trimmedEventDate);

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -28,7 +28,6 @@ import seedu.address.model.tag.Tag;
 public class ParserUtil {
 
     public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer.";
-    public static final String MESSAGE_INVALID_IMPORTANCE = "Illegal Importance parsed";
 
     /**
      * Parses {@code oneBasedIndex} into an {@code Index} and returns it. Leading and trailing whitespaces will be

--- a/src/main/java/seedu/address/logic/parser/RemoveParticipantFromEventParser.java
+++ b/src/main/java/seedu/address/logic/parser/RemoveParticipantFromEventParser.java
@@ -1,7 +1,6 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.commons.core.Messages.MESSAGE_INVALID_ZERO_BASED_INDEX;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.RemoveParticipantFromEventCommand;
@@ -17,13 +16,8 @@ public class RemoveParticipantFromEventParser implements Parser<RemoveParticipan
                     MESSAGE_INVALID_COMMAND_FORMAT, RemoveParticipantFromEventCommand.MESSAGE_USAGE));
         }
 
-        try {
-            Index participantIndex = ParserUtil.parseIndex(sections[1]);
-            Index eventIndex = ParserUtil.parseIndex(sections[2]);
-            return new RemoveParticipantFromEventCommand(participantIndex, eventIndex);
-        } catch (ParseException pe) {
-            throw new ParseException(MESSAGE_INVALID_ZERO_BASED_INDEX);
-        }
-
+        Index participantIndex = ParserUtil.parseIndex(sections[1]);
+        Index eventIndex = ParserUtil.parseIndex(sections[2]);
+        return new RemoveParticipantFromEventCommand(participantIndex, eventIndex);
     }
 }

--- a/src/main/java/seedu/address/model/event/EventDate.java
+++ b/src/main/java/seedu/address/model/event/EventDate.java
@@ -14,7 +14,8 @@ import java.time.format.DateTimeFormatter;
  */
 public class EventDate implements Comparable<EventDate> {
 
-    public static final String MESSAGE_CONSTRAINTS = "Dates should be in YYYY-MM-DD format!";
+    public static final String MESSAGE_CONSTRAINTS = "Date does not exists!";
+    public static final String MESSAGE_DATE_FORMAT_ERROR = "Dates should be in YYYY-MM-DD format!";
     public static final String DATE_FORMAT = "y-M-d";
 
     private final LocalDate date;
@@ -45,6 +46,10 @@ public class EventDate implements Comparable<EventDate> {
             return false;
         }
         return true;
+    }
+
+    public static boolean checkDateComponents(String date) {
+        return date.split("-").length == 3;
     }
 
     @Override

--- a/src/main/java/seedu/address/model/event/EventDate.java
+++ b/src/main/java/seedu/address/model/event/EventDate.java
@@ -14,7 +14,7 @@ import java.time.format.DateTimeFormatter;
  */
 public class EventDate implements Comparable<EventDate> {
 
-    public static final String MESSAGE_CONSTRAINTS = "Date does not exists!";
+    public static final String MESSAGE_CONSTRAINTS = "Date does not exist!";
     public static final String MESSAGE_DATE_FORMAT_ERROR = "Dates should be in YYYY-MM-DD format!";
     public static final String DATE_FORMAT = "y-M-d";
 

--- a/src/main/java/seedu/address/model/event/EventTime.java
+++ b/src/main/java/seedu/address/model/event/EventTime.java
@@ -15,7 +15,7 @@ import java.time.format.DateTimeFormatter;
 public class EventTime implements Comparable<EventTime> {
 
     public static final String MESSAGE_CONSTRAINTS = "Time should be in 24hr format. "
-            + "Input time should be from 0000 to 2359 inclusively.";
+            + "Input time should be from 0000 to 2359 inclusive.";
     private static final String TIME_FORMAT = "HHmm";
     private static final String TIME_DISPLAY_FORMAT = "HH:mm";
 

--- a/src/main/java/seedu/address/model/event/EventTime.java
+++ b/src/main/java/seedu/address/model/event/EventTime.java
@@ -14,7 +14,8 @@ import java.time.format.DateTimeFormatter;
  */
 public class EventTime implements Comparable<EventTime> {
 
-    public static final String MESSAGE_CONSTRAINTS = "Time should be in 2359 format.";
+    public static final String MESSAGE_CONSTRAINTS = "Time should be in 24hr format. "
+            + "Input time should be from 0000 to 2359 inclusively.";
     private static final String TIME_FORMAT = "HHmm";
     private static final String TIME_DISPLAY_FORMAT = "HH:mm";
 

--- a/src/main/java/seedu/address/model/participant/BirthDate.java
+++ b/src/main/java/seedu/address/model/participant/BirthDate.java
@@ -8,6 +8,7 @@ import java.text.SimpleDateFormat;
 import java.time.LocalDate;
 import java.time.Period;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 
 /**
  * Represents a Participant's date of birth in the event.
@@ -15,7 +16,9 @@ import java.time.format.DateTimeFormatter;
  */
 public class BirthDate {
 
-    public static final String MESSAGE_DATE_CONSTRAINTS = "Date of birth cannot be in the future or invalid";
+    public static final String MESSAGE_DATE_CONSTRAINTS = "Date of birth cannot be in the future.";
+    public static final String MESSAGE_DATE_FORMAT_ERROR = "Dates should be in YYYY-MM-DD format!";
+    public static final String MESSAGE_DATE_DOES_NOT_EXIST = "Date does not exists!";
     public static final String DATE_FORMAT = "y-M-d";
     private final LocalDate date;
 
@@ -89,7 +92,6 @@ public class BirthDate {
         return (LocalDate.now().isEqual(date) || LocalDate.now().isAfter(date));
     }
 
-    //Add on for Json Conversion in JsonAdaptedParticipants
     /**
      * Returns true if a given String form of birthDate is valid.
      *
@@ -98,16 +100,36 @@ public class BirthDate {
      */
     public static boolean isValidBirthDate(String birthDate) {
         boolean isValid;
+        try {
+            LocalDate date = LocalDate.parse(birthDate, DateTimeFormatter.ofPattern(DATE_FORMAT));
+            isValid = isPresentOrPast(date);
+        } catch (DateTimeParseException e) {
+            isValid = false;
+        }
+        return isValid;
+    }
+
+    /**
+     * Returns true if a given String form is a valid date.
+     *
+     * @param date  A String representing a date.
+     * @return      A boolean indicating if it is a valid date.
+     */
+    public static boolean isValidDate(String date) {
+        boolean isValid;
         DateFormat sdf = new SimpleDateFormat(DATE_FORMAT);
         sdf.setLenient(false);
         try {
-            sdf.parse(birthDate);
-            LocalDate date = LocalDate.parse(birthDate, DateTimeFormatter.ofPattern(DATE_FORMAT));
-            isValid = isPresentOrPast(date);
+            sdf.parse(date);
+            isValid = true;
         } catch (ParseException e) {
             isValid = false;
         }
         return isValid;
+    }
+
+    public static boolean checkDateComponents(String date) {
+        return date.split("-").length == 3;
     }
 
     @Override

--- a/src/main/java/seedu/address/model/participant/BirthDate.java
+++ b/src/main/java/seedu/address/model/participant/BirthDate.java
@@ -18,7 +18,7 @@ public class BirthDate {
 
     public static final String MESSAGE_DATE_CONSTRAINTS = "Date of birth cannot be in the future.";
     public static final String MESSAGE_DATE_FORMAT_ERROR = "Dates should be in YYYY-MM-DD format!";
-    public static final String MESSAGE_DATE_DOES_NOT_EXIST = "Date does not exists!";
+    public static final String MESSAGE_DATE_DOES_NOT_EXIST = "Date does not exist!";
     public static final String DATE_FORMAT = "y-M-d";
     private final LocalDate date;
 

--- a/src/main/java/seedu/address/storage/JsonAdaptedParticipant.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedParticipant.java
@@ -106,7 +106,7 @@ public class JsonAdaptedParticipant {
         final Address modelAddress = new Address(address);
 
         BirthDate modelBirthDate;
-        if (!BirthDate.isValidBirthDate(this.birthDate)) {
+        if (!(BirthDate.isValidDate(this.birthDate) && BirthDate.isValidBirthDate(this.birthDate))) {
             // throw new IllegalValueException(BirthDate.MESSAGE_DATE_CONSTRAINTS);
             // Can't do this due to BirthDate implementation
             modelBirthDate = BirthDate.notSpecified();

--- a/src/test/java/seedu/address/logic/commands/AddParticipantToEventCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddParticipantToEventCommandTest.java
@@ -69,15 +69,16 @@ class AddParticipantToEventCommandTest {
         Participant validParticipant = new ParticipantBuilder().build();
         EventBuilder eventBuilder = new EventBuilder();
         eventBuilder.addParticipant(validParticipant);
+        Event event = eventBuilder.build();
 
         ModelStubWithEventAndParticipant modelStub =
-                new ModelStubWithEventAndParticipant(validParticipant, eventBuilder.build());
+                new ModelStubWithEventAndParticipant(validParticipant, event);
 
         AddParticipantToEventCommand addParticipantToEventCommand =
                 new AddParticipantToEventCommand(Index.fromOneBased(1), Index.fromOneBased(1));
 
         assertThrows(CommandException.class,
-                Messages.showParticipantExists(validParticipant.getFullName()), () ->
+                Messages.showParticipantAlreadyEnrolled(validParticipant.getFullName(), event.getNameString()), () ->
                         addParticipantToEventCommand.execute(modelStub));
     }
 

--- a/src/test/java/seedu/address/logic/parser/EditEventCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditEventCommandParserTest.java
@@ -72,13 +72,13 @@ public class EditEventCommandParserTest {
         // invalid EventName
         assertParseFailure(parser, "1" + INVALID_EVENT_NAME_DESC, EventName.MESSAGE_CONSTRAINTS);
         // invalid EventDate
-        assertParseFailure(parser, "1" + INVALID_EVENT_DATE_DESC, EventDate.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, "1" + INVALID_EVENT_DATE_DESC, EventDate.MESSAGE_DATE_FORMAT_ERROR);
         // invalid EventTime
         assertParseFailure(parser, "1" + INVALID_EVENT_TIME_DESC, EventTime.MESSAGE_CONSTRAINTS);
 
         // valid EventName followed by invalid EventDate
         assertParseFailure(parser, "1" + EVENT_NAME_DESC_JOGGING + INVALID_EVENT_DATE_DESC,
-                EventDate.MESSAGE_CONSTRAINTS);
+                EventDate.MESSAGE_DATE_FORMAT_ERROR);
 
         // invalid EventName followed by valid EventDate
         assertParseFailure(parser, "1" + INVALID_EVENT_NAME_DESC + EVENT_DATE_DESC_JOGGING,


### PR DESCRIPTION
This PR makes the following changes/fixes to the main repo:

- Changed `...2359 format` for time to `Time should be in 24hr format. Input time should be from 0000 to 2359 inclusively.`
- Generalised error messages for index to use `MESSAGE_INVALID_INDEX` in ParseUtil.java
- Updated error messages for enroll/expel error messages to mention both participants name and event name
- Add more layers of checks in ParserUtil::parseBirthDate to check for formatting, if the date exists and if it is valid (i.e. not in the future) with different error messages for each case.
- Add 1 more layer of checks in ParserUtil::parseEventDate to check for formatting with a different error message to be displayed


Other miscellaneous changes:
- Update `MESSAGE_USAGE`s to remove instances of "address book" and replace with "managera"
- Update `MESSAGE_CONSTRAINTS` of numerous classes
- Update test cases