### PR TITLE
Fix issues relating to past or completed Events and NOK parsers

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -7,7 +7,7 @@ public class Messages {
 
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
-    public static final String MESSAGE_EVENTS_LISTED_OVERVIEW = "%1$d events listed!";
+    public static final String MESSAGE_EVENTS_LISTED_OVERVIEW = "%1$d event(s) listed!";
     public static final String MESSAGE_EVENT_NOT_FOUND = "The Event you are looking for does not exist!";
     public static final String MESSAGE_INVALID_PARTICIPANT_DISPLAYED_INDEX =
             "The participant index provided is invalid!";
@@ -16,10 +16,6 @@ public class Messages {
     public static final String MESSAGE_PARTICIPANTS_LISTED_OVERVIEW = "%1$d participants listed";
     public static final String MESSAGE_INVALID_ZERO_BASED_INDEX =
             "The index provided cannot be less than or equal to 0";
-    public static final String MESSAGE_PARTICIPANT_NOT_FOUND = "Participant of id: %1$s not found, consider "
-            + "relisting the participants using '%2$s'";
-    public static final String MESSAGE_EVENT_NOT_FOUND_IN_FILTERED_LIST =
-            "Event %1$s Not Found, consider relisting events using '%2$s'";
 
     /**
      * Forms the message that states that a Participant already exists in an Event in Managera.

--- a/src/main/java/seedu/address/logic/commands/AddNextOfKinCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddNextOfKinCommand.java
@@ -30,7 +30,7 @@ public class AddNextOfKinCommand extends Command {
             + PREFIX_PHONE + "98234532 "
             + PREFIX_TAG + "Spouse ";
 
-    public static final String MESSAGE_SUCCESS = "Added \n%1$s \nto %2$s successfully";
+    public static final String MESSAGE_SUCCESS = "Added next of kin %1$s to participant %2$s successfully";
 
     private final Index participantIndex;
     private final NextOfKin nextOfKin;
@@ -70,7 +70,7 @@ public class AddNextOfKinCommand extends Command {
         selectedParticipant.addNextOfKin(nextOfKin);
 
         return new CommandResult(String.format(MESSAGE_SUCCESS,
-                nextOfKin, selectedParticipant.getFullName()));
+                nextOfKin.getFullName(), selectedParticipant.getFullName()));
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/AddParticipantToEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddParticipantToEventCommand.java
@@ -9,6 +9,7 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.event.Event;
+import seedu.address.model.event.EventDate;
 import seedu.address.model.participant.Participant;
 
 public class AddParticipantToEventCommand extends Command {
@@ -23,6 +24,8 @@ public class AddParticipantToEventCommand extends Command {
             + "Example: " + COMMAND_WORD + " 1 2";
 
     public static final String MESSAGE_ADD_PARTICIPANT_TO_EVENT_SUCCESS = "Added %1$s to %2$s successfully";
+    public static final String MESSAGE_COMPLETED_EVENT = "Cannot add a Participant to a completed Event!";
+    public static final String MESSAGE_PAST_EVENT = "Cannot add a Participant to a past Event!";
 
     private final Index participantIndex;
     private final Index eventIndex;
@@ -54,6 +57,11 @@ public class AddParticipantToEventCommand extends Command {
 
         try {
             selectedEvent = lastShownEventList.get(eventIndex.getZeroBased());
+            if (selectedEvent.getDoneValue()) {
+                throw new CommandException(MESSAGE_COMPLETED_EVENT);
+            } else if (!EventDate.isPresentOrFuture(selectedEvent.getDateString())) {
+                throw new CommandException(MESSAGE_PAST_EVENT);
+            }
         } catch (IndexOutOfBoundsException e) {
             throw new CommandException(Messages.MESSAGE_INVALID_EVENT_DISPLAYED_INDEX);
         }

--- a/src/main/java/seedu/address/logic/commands/DeleteNextOfKinCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteNextOfKinCommand.java
@@ -22,7 +22,7 @@ public class DeleteNextOfKinCommand extends Command {
             + "PARTICIPANT_INDEX\n"
             + "Example: " + COMMAND_WORD + " 1 2";
 
-    public static final String MESSAGE_SUCCESS = "Removed \n%1$s \nfrom %2$s successfully";
+    public static final String MESSAGE_SUCCESS = "Removed next of kin %1$s from participant %2$s successfully";
     public static final String MESSAGE_INVALID_NOK_INDEX = "The next-of-kin index provided is invalid!";
 
     private final Index nextOfKinIndex;

--- a/src/main/java/seedu/address/logic/parser/AddNextOfKinParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddNextOfKinParser.java
@@ -21,7 +21,7 @@ public class AddNextOfKinParser implements Parser<AddNextOfKinCommand> {
     @Override
     public AddNextOfKinCommand parse(String args) throws ParseException {
 
-        String[] sections = args.split(" ");
+        String[] sections = args.split("\\s+");
 
         if (sections.length < 5) {
             throw new ParseException(String.format(

--- a/src/main/java/seedu/address/logic/parser/DeleteNextOfKinParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteNextOfKinParser.java
@@ -10,7 +10,7 @@ import seedu.address.logic.parser.exceptions.ParseException;
 public class DeleteNextOfKinParser implements Parser<DeleteNextOfKinCommand> {
     @Override
     public DeleteNextOfKinCommand parse(String args) throws ParseException {
-        String[] sections = args.split(" ");
+        String[] sections = args.split("\\s+");
 
         if (sections.length != 3) {
             throw new ParseException(String.format(

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -28,7 +28,6 @@ import seedu.address.model.tag.Tag;
 public class ParserUtil {
 
     public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer.";
-    public static final String MESSAGE_INVALID_IMPORTANCE = "Illegal Importance parsed";
 
     /**
      * Parses {@code oneBasedIndex} into an {@code Index} and returns it. Leading and trailing whitespaces will be
@@ -186,6 +185,8 @@ public class ParserUtil {
         String trimmedEventDate = eventDate.trim();
         if (!EventDate.isValidDate(trimmedEventDate)) {
             throw new ParseException(EventDate.MESSAGE_CONSTRAINTS);
+        } else if (!EventDate.isPresentOrFuture(trimmedEventDate)) {
+            throw new ParseException(EventDate.MESSAGE_PAST_DATE);
         }
         return new EventDate(trimmedEventDate);
     }

--- a/src/main/java/seedu/address/model/event/EventDate.java
+++ b/src/main/java/seedu/address/model/event/EventDate.java
@@ -60,7 +60,7 @@ public class EventDate implements Comparable<EventDate> {
         LocalDate date = LocalDate.parse(test, DateTimeFormatter.ofPattern(DATE_FORMAT));
         return (LocalDate.now().isEqual(date) || LocalDate.now().isBefore(date));
     }
-        
+
     public static boolean checkDateComponents(String date) {
         return date.split("-").length == 3;
     }

--- a/src/main/java/seedu/address/model/event/EventDate.java
+++ b/src/main/java/seedu/address/model/event/EventDate.java
@@ -15,7 +15,7 @@ import java.time.format.DateTimeFormatter;
 public class EventDate implements Comparable<EventDate> {
 
     public static final String MESSAGE_CONSTRAINTS = "Dates should be in YYYY-MM-DD format!";
-    public static final String MESSAGE_PAST_DATE = "Date of new Event cannot be in the past!";
+    public static final String MESSAGE_PAST_DATE = "Event date cannot be in the past!";
     public static final String DATE_FORMAT = "y-M-d";
 
     private final LocalDate date;

--- a/src/main/java/seedu/address/model/event/EventDate.java
+++ b/src/main/java/seedu/address/model/event/EventDate.java
@@ -15,6 +15,7 @@ import java.time.format.DateTimeFormatter;
 public class EventDate implements Comparable<EventDate> {
 
     public static final String MESSAGE_CONSTRAINTS = "Dates should be in YYYY-MM-DD format!";
+    public static final String MESSAGE_PAST_DATE = "Date of new Event cannot be in the past!";
     public static final String DATE_FORMAT = "y-M-d";
 
     private final LocalDate date;
@@ -45,6 +46,18 @@ public class EventDate implements Comparable<EventDate> {
             return false;
         }
         return true;
+    }
+
+    /**
+     * Returns true if a given LocalDate instance is in the present or future.
+     * This is used to ensure the Event date is not in the past.
+     *
+     * @param test     A String representation of a LocalDate instance.
+     * @return         A boolean representing if the date is in the present or future.
+     */
+    public static boolean isPresentOrFuture(String test) {
+        LocalDate date = LocalDate.parse(test, DateTimeFormatter.ofPattern(DATE_FORMAT));
+        return (LocalDate.now().isEqual(date) || LocalDate.now().isBefore(date));
     }
 
     @Override

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -56,14 +56,14 @@ public class SampleDataUtil {
             new Event(new EventName("Managera Marketing Team Retreat"),
                     new EventDate("2022-08-20"), new EventTime("0900")),
             new Event(new EventName("Managera Product Team Retreat"),
-                    new EventDate("2021-09-21"), new EventTime("0800")),
+                    new EventDate("2022-09-21"), new EventTime("0800")),
             new Event(new EventName("Managera Annual Shareholder Meeting"),
-                    new EventDate("2021-11-20"), new EventTime("0900")),
-            new Event(new EventName("Managera Dinner and Dance"), new EventDate("2021-09-30")),
-            new Event(new EventName("Monthly Roundup 28"), new EventDate("2021-09-26"), new EventTime("0900")),
-            new Event(new EventName("Monthly Roundup 29"), new EventDate("2021-10-28"), new EventTime("0900")),
-            new Event(new EventName("Monthly Roundup 30"), new EventDate("2021-11-28"), new EventTime("0900")),
-            new Event(new EventName("Managera Alpha Release Milestone"), new EventDate("2021-09-20")),
+                    new EventDate("2022-11-20"), new EventTime("0900")),
+            new Event(new EventName("Managera Dinner and Dance"), new EventDate("2022-09-30")),
+            new Event(new EventName("Monthly Roundup 28"), new EventDate("2022-09-26"), new EventTime("0900")),
+            new Event(new EventName("Monthly Roundup 29"), new EventDate("2022-10-28"), new EventTime("0900")),
+            new Event(new EventName("Monthly Roundup 30"), new EventDate("2022-11-28"), new EventTime("0900")),
+            new Event(new EventName("Managera Alpha Release Milestone"), new EventDate("2022-09-20")),
         };
     }
 

--- a/src/main/java/seedu/address/ui/EventCard.java
+++ b/src/main/java/seedu/address/ui/EventCard.java
@@ -39,7 +39,7 @@ public class EventCard extends UiPart<Region> {
         date.setText(event.getDateString());
         time.setText(event.getTimeDisplayString());
         int noOfParticipants = event.getParticipants().size();
-        if (noOfParticipants <= 1) {
+        if (noOfParticipants == 1) {
             numberOfParticipants.setText(String.format("%d participant", noOfParticipants));
         } else {
             numberOfParticipants.setText(String.format("%d participants", noOfParticipants));

--- a/src/test/data/JsonSerializableAddressBookTest/duplicateEventAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/duplicateEventAddressBook.json
@@ -4,13 +4,13 @@
     {
       "name" : "Sleep",
       "isDone" : "Uncompleted",
-      "date" : "2021-09-18",
+      "date" : "2022-09-18",
       "time" : "1000",
       "participants" : [ ]
     }, {
       "name" : "Sleep",
       "isDone" : "Uncompleted",
-      "date" : "2021-09-18",
+      "date" : "2022-09-18",
       "time" : "1000",
       "participants" : [ ]
     }

--- a/src/test/data/JsonSerializableAddressBookTest/invalidEventAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/invalidEventAddressBook.json
@@ -4,7 +4,7 @@
      {
        "name" : "^^^asda",
        "isDone" : "Uncompleted",
-       "date" : "2021-09-18",
+       "date" : "2022-09-18",
        "time" : "1000",
        "participants" : [ ]
      }

--- a/src/test/data/JsonSerializableAddressBookTest/typicalEventsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalEventsAddressBook.json
@@ -5,13 +5,13 @@
     {
       "name" : "Sleep",
       "isDone" : "Uncompleted",
-      "date" : "2021-09-18",
+      "date" : "2022-09-18",
       "time" : "1000",
       "participants" : [ ]
     }, {
       "name" : "Sleep2",
       "isDone" : "Uncompleted",
-      "date" : "2021-09-18",
+      "date" : "2022-09-18",
       "time" : "1001",
       "participants" : [ ]
     }

--- a/src/test/java/seedu/address/logic/commands/AddNextOfKinCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddNextOfKinCommandTest.java
@@ -32,7 +32,7 @@ public class AddNextOfKinCommandTest {
         CommandResult commandResult =
                 new AddNextOfKinCommand(Index.fromOneBased(1), SARAH).execute(modelStub);
 
-        assertEquals(String.format(MESSAGE_SUCCESS, SARAH,
+        assertEquals(String.format(MESSAGE_SUCCESS, SARAH.getFullName(),
                 validParticipant.getFullName()), commandResult.getFeedbackToUser());
 
         assertTrue(validParticipant.hasNextOfKin(SARAH));

--- a/src/test/java/seedu/address/logic/commands/CommandResultTest.java
+++ b/src/test/java/seedu/address/logic/commands/CommandResultTest.java
@@ -68,7 +68,7 @@ public class CommandResultTest {
     @Test
     public void isShowHelp_addEventCommand_returnsFalse() throws Exception {
         // CommandResult from AddEventCommand
-        assertFalse(new AddEventCommandParser().parse(" n/Marathon SG d/2021-10-10").execute(model).isShowHelp());
+        assertFalse(new AddEventCommandParser().parse(" n/Marathon SG d/2022-10-10").execute(model).isShowHelp());
     }
 
     @Test
@@ -200,7 +200,7 @@ public class CommandResultTest {
     @Test
     public void isExit_addEventCommand_returnsFalse() throws Exception {
         // CommandResult from AddEventCommand
-        assertFalse(new AddEventCommandParser().parse(" n/Marathon SG d/2021-10-10").execute(model).isExit());
+        assertFalse(new AddEventCommandParser().parse(" n/Marathon SG d/2022-10-10").execute(model).isExit());
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -66,7 +66,7 @@ public class CommandTestUtil {
 
     public static final String VALID_EVENT_NAME_SLEEP = "Sleep";
     public static final String VALID_EVENT_NAME_JOGGING = "Jogging";
-    public static final String VALID_EVENT_DATE_SLEEP = "2021-10-10";
+    public static final String VALID_EVENT_DATE_SLEEP = "2022-10-10";
     public static final String VALID_EVENT_DATE_JOGGING = "2022-12-12";
     public static final String VALID_EVENT_TIME_SLEEP = "0000";
     public static final String VALID_EVENT_TIME_JOGGING = "2359";

--- a/src/test/java/seedu/address/logic/commands/FilterEventCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FilterEventCommandTest.java
@@ -27,9 +27,9 @@ public class FilterEventCommandTest {
     @Test
     public void equals() {
         EventDateTimePredicate firstPredicate =
-                new EventDateTimePredicate(Collections.singletonList("2021-09-18"));
+                new EventDateTimePredicate(Collections.singletonList("2022-09-18"));
         EventDateTimePredicate secondPredicate =
-                new EventDateTimePredicate(Arrays.asList("2021-09-18", "1000"));
+                new EventDateTimePredicate(Arrays.asList("2022-09-18", "1000"));
 
         FilterEventCommand filterFirstCommand = new FilterEventCommand(firstPredicate);
         FilterEventCommand filterSecondCommand = new FilterEventCommand(secondPredicate);
@@ -55,7 +55,7 @@ public class FilterEventCommandTest {
     public void execute_onlyDateInput_multipleEventsFound() {
         String expectedMessage = String.format(MESSAGE_EVENTS_LISTED_OVERVIEW, 4);
         EventDateTimePredicate predicate =
-                new EventDateTimePredicate(Collections.singletonList("2021-09-18"));
+                new EventDateTimePredicate(Collections.singletonList("2022-09-18"));
         FilterEventCommand command = new FilterEventCommand(predicate);
         expectedModel.updateFilteredEventList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
@@ -66,7 +66,7 @@ public class FilterEventCommandTest {
     public void execute_dateAndTimeInput_oneEventFound() {
         String expectedMessage = String.format(MESSAGE_EVENTS_LISTED_OVERVIEW, 1);
         EventDateTimePredicate predicate =
-                new EventDateTimePredicate(Arrays.asList("2021-09-18", "1001"));
+                new EventDateTimePredicate(Arrays.asList("2022-09-18", "1001"));
         FilterEventCommand command = new FilterEventCommand(predicate);
         expectedModel.updateFilteredEventList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
@@ -88,7 +88,7 @@ public class FilterEventCommandTest {
     public void execute_dateAndTimeInput_noEventFound() {
         String expectedMessage = String.format(MESSAGE_EVENTS_LISTED_OVERVIEW, 0);
         EventDateTimePredicate predicate =
-                new EventDateTimePredicate(Arrays.asList("2021-09-18", "1020"));
+                new EventDateTimePredicate(Arrays.asList("2022-09-18", "1020"));
         FilterEventCommand command = new FilterEventCommand(predicate);
         expectedModel.updateFilteredEventList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);

--- a/src/test/java/seedu/address/testutil/EventBuilder.java
+++ b/src/test/java/seedu/address/testutil/EventBuilder.java
@@ -11,7 +11,7 @@ import seedu.address.model.participant.Participant;
 public class EventBuilder {
 
     public static final String DEFAULT_EVENT_NAME = "Sleep";
-    public static final String DEFAULT_EVENT_DATE = "2021-09-18";
+    public static final String DEFAULT_EVENT_DATE = "2022-09-18";
     public static final String DEFAULT_EVENT_TIME = "1000";
 
     private ObservableList<Participant> participants = FXCollections.observableArrayList();

--- a/src/test/java/seedu/address/testutil/TypicalEvents.java
+++ b/src/test/java/seedu/address/testutil/TypicalEvents.java
@@ -15,41 +15,39 @@ import seedu.address.model.event.EventTime;
  * An utility class containing a list of {@code Event} objects to be used in tests.
  */
 public class TypicalEvents {
-    public static final Event SAMPLE_EVENT = new Event(new EventName("Sleep"), new EventDate("2021-09-18"),
+    public static final Event SAMPLE_EVENT = new Event(new EventName("Sleep"), new EventDate("2022-09-18"),
             new EventTime("1000"));
-    public static final Event ANOTHER_EVENT = new Event(new EventName("Sleep2"), new EventDate("2021-09-18"),
+    public static final Event ANOTHER_EVENT = new Event(new EventName("Sleep2"), new EventDate("2022-09-18"),
             new EventTime("1001"));
     public static final Event SAMPLE_EVENT_2 = new Event(new EventName("Random Event 1"),
-            new EventDate("1-1-1"), new EventTime("0001"));
-    public static final Event SAMPLE_EVENT_3 = new Event(new EventName("Sleep"), new EventDate("2021-09-18"),
-            new EventTime("1002"), false, Collections.singletonList(new ParticipantBuilder().build()));
+            new EventDate("2111-1-1"), new EventTime("0001"));
     public static final Event MARATHON_NO_TIME = new Event(new EventName("24km Marathon"),
-            new EventDate("2021-10-5"), new EventTime());
+            new EventDate("2022-10-5"), new EventTime());
     public static final Event MARATHON_HAS_TIME = new Event(new EventName("24Km Marathon with Time"),
-            new EventDate("2021-10-5"), new EventTime("0800"));
+            new EventDate("2022-10-5"), new EventTime("0800"));
     public static final Event CODE_FOR_SANITY = new Event(new EventName("Code For Sanity"),
-            new EventDate("2021-8-10"), new EventTime("0000"));
+            new EventDate("2022-8-10"), new EventTime("0000"));
     public static final Event SAMPLE_EVENT_SPECIFIED_TIME_AND_COMPLETION = new Event(new EventName("Sleep"),
-            new EventDate("2021-09-18"), new EventTime("1002"), true,
+            new EventDate("2022-09-18"), new EventTime("1002"), true,
             Collections.singletonList(new ParticipantBuilder().build()));
     public static final Event SAMPLE_EVENT_SPECIFIED_TIME_AND_COMPLETION_COPY = new Event(new EventName("Sleep"),
-            new EventDate("2021-09-18"), new EventTime("1002"), true,
+            new EventDate("2022-09-18"), new EventTime("1002"), true,
             Collections.singletonList(new ParticipantBuilder().build()));
     public static final Event SAMPLE_EVENT_DEFAULT_TIME_AND_COMPLETION = new Event(new EventName("Sleep again"),
-            new EventDate("2021-09-18"));
+            new EventDate("2022-09-18"));
     public static final Event SAMPLE_EVENT_COPY_DIFFERENT_NAME = new Event(new EventName("Sleeps"),
-            new EventDate("2021-09-18"), new EventTime("1000"));
+            new EventDate("2022-09-18"), new EventTime("1000"));
     public static final Event SAMPLE_EVENT_COPY_DIFFERENT_DATE = new Event(new EventName("Sleep"),
-            new EventDate("2021-09-19"), new EventTime("1000"));
+            new EventDate("2022-09-19"), new EventTime("1000"));
     public static final Event SAMPLE_EVENT_COPY_DIFFERENT_TIME = new Event(new EventName("Sleep"),
-            new EventDate("2021-09-18"), new EventTime("1001"));
+            new EventDate("2022-09-18"), new EventTime("1001"));
     public static final Event SAMPLE_EVENT_COPY_DIFFERENT_COMPLETION = new Event(new EventName("Sleep"),
-            new EventDate("2021-09-18"), new EventTime("1000"), true, new ArrayList<>());
+            new EventDate("2022-09-18"), new EventTime("1000"), true, new ArrayList<>());
     public static final Event SAMPLE_EVENT_COPY_DIFFERENT_PARTICIPANTS = new Event(new EventName("Sleep"),
-            new EventDate("2021-09-18"), new EventTime("1000"), false,
+            new EventDate("2022-09-18"), new EventTime("1000"), false,
             Collections.singletonList(new ParticipantBuilder().build()));
     public static final Event SAMPLE_EVENT_COPY_NO_TIME = new Event(new EventName("Slept"),
-            new EventDate("2021-09-18"));
+            new EventDate("2022-09-18"));
 
     private TypicalEvents() {}
 


### PR DESCRIPTION
Fixes:
- Possible to add Events in the past
    - add method in EventDate to check if given date is in the present/future
    - add guard clause in parseEventDate in ParserUtil (which is used in AddEventCommand) to throw exception if given date is past
- Possible to add Participant to completed Event
    - add guard clauses in AddParticipantToEventCommand to throw exceptions if Event is completed or in the past
- Possible to add Participant to Event before date of birth
    - prevented by preventing adding of Events in the past (added above) and adding of Birthdates in the future (existing)
- Displaying a single Event returns "1 events listed"
    - change message to "event(s) listed"
- addNok and deleteNok commands cannot handle extra whitespaces
    - modify split regex to handle whitespaces
- Misc
    - Update MESSAGE_SUCCESS for NOK classes
    - Update EventCard
    - Update test classes (mostly changing all the sample dates to in the future)