### PR TITLE
Change definition of Participant equality to allow Participants with the same name

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -34,7 +34,7 @@ public class AddCommand extends Command {
             + PREFIX_ADDRESS + "311, Clementi Ave 2, #02-25 ";
 
     public static final String MESSAGE_SUCCESS = "Added participant:\n%1$s";
-    public static final String MESSAGE_DUPLICATE_PARTICIPANT = "This participant already exists in the address book";
+    public static final String MESSAGE_DUPLICATE_PARTICIPANT = "This participant already exists!";
 
     private final Participant toAdd;
 
@@ -67,6 +67,24 @@ public class AddCommand extends Command {
         }
         AddCommand otherAddCommand = (AddCommand) other;
         return otherAddCommand.toAdd.equals(toAdd);
+    }
+
+    /**
+     * Checks if two AddCommand objects contain Participants with identical details, except Participant ID.
+     * For testing usage in AddCommandTest only.
+     *
+     * @param command First AddCommand.
+     * @param otherCommand Second AddCommand.
+     * @return true if one object's Participant has the same details as the other AddCommand's Participant, except ID.
+     */
+    public static boolean isAddingSameParticipant(Command command, Command otherCommand) {
+        if (command instanceof AddCommand && otherCommand instanceof AddCommand) {
+            AddCommand addCommand = (AddCommand) command;
+            AddCommand otherAddCommand = (AddCommand) otherCommand;
+            return otherAddCommand.toAdd.isSameParticipant(addCommand.toAdd);
+        } else {
+            return false;
+        }
     }
 
     @Override

--- a/src/main/java/seedu/address/model/participant/Participant.java
+++ b/src/main/java/seedu/address/model/participant/Participant.java
@@ -234,7 +234,11 @@ public class Participant {
 
         return otherParticipant != null
                 && otherParticipant.getName().equals(getName())
-                && otherParticipant.getBirthDate().equals(getBirthDate());
+                && otherParticipant.getPhone().equals(getPhone())
+                && otherParticipant.getEmail().equals(getEmail())
+                && otherParticipant.getAddress().equals(getAddress())
+                && otherParticipant.getBirthDate().equals(getBirthDate())
+                && otherParticipant.getNextOfKins().equals(getNextOfKins());
     }
 
     /**
@@ -293,7 +297,9 @@ public class Participant {
                 && otherParticipant.getEmail().equals(getEmail())
                 && otherParticipant.getAddress().equals(getAddress())
                 && otherParticipant.getBirthDate().equals(getBirthDate())
-                && otherParticipant.getNextOfKins().equals(getNextOfKins());
+                && otherParticipant.getNextOfKins().equals(getNextOfKins())
+                && otherParticipant.getParticipantId().equals(getParticipantId());
+
     }
 
     @Override

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -1,6 +1,7 @@
 package seedu.address.logic;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_PARTICIPANT_DISPLAYED_INDEX;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
@@ -16,6 +17,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import javafx.collections.ObservableList;
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.ListCommand;
@@ -147,7 +149,13 @@ public class LogicManagerTest {
     private void assertCommandFailure(String inputCommand, Class<? extends Throwable> expectedException,
             String expectedMessage, Model expectedModel) {
         assertThrows(expectedException, expectedMessage, () -> logic.execute(inputCommand));
-        assertEquals(expectedModel, model);
+        assertEquals(expectedModel.getUserPrefs(), model.getUserPrefs());
+        assertEquals(expectedModel.getFilteredEventList(), model.getFilteredEventList());
+        ObservableList<Participant> actualList = model.getFilteredParticipantList();
+        ObservableList<Participant> expectedList = expectedModel.getFilteredParticipantList();
+        for (int i = 0; i < expectedList.size(); i++) {
+            assertTrue(actualList.get(i).isSameParticipant(expectedList.get(i)));
+        }
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -15,6 +15,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.AddressBook;
@@ -105,9 +106,13 @@ public class CommandTestUtil {
     public static void assertCommandSuccess(Command command, Model actualModel, CommandResult expectedCommandResult,
             Model expectedModel) {
         try {
-            CommandResult result = command.execute(actualModel);
-            assertEquals(expectedCommandResult, result);
-            assertEquals(expectedModel, actualModel);
+            if (command instanceof EditCommand) {
+                assertEditCommandSuccess(command, actualModel, expectedCommandResult, expectedModel);
+            } else {
+                CommandResult result = command.execute(actualModel);
+                assertEquals(expectedCommandResult, result);
+                assertEquals(expectedModel, actualModel);
+            }
         } catch (CommandException ce) {
             throw new AssertionError("Execution of command should not fail.", ce);
         }
@@ -121,6 +126,35 @@ public class CommandTestUtil {
             Model expectedModel) {
         CommandResult expectedCommandResult = new CommandResult(expectedMessage);
         assertCommandSuccess(command, actualModel, expectedCommandResult, expectedModel);
+    }
+
+    /**
+     * Executes the given {@code command}, confirms that <br>
+     * - the returned {@link CommandResult} matches {@code expectedCommandResult} <br>
+     * - the {@code actualModel} matches {@code expectedModel}
+     * Used only for testing of EditCommand.
+     */
+    public static void assertEditCommandSuccess(Command command, Model actualModel, CommandResult expectedCommandResult,
+                                                Model expectedModel) {
+        try {
+            if (command instanceof EditCommand) {
+                CommandResult result = command.execute(actualModel);
+                assertEquals(expectedCommandResult, result);
+                assertEquals(expectedModel.getUserPrefs(), actualModel.getUserPrefs());
+                assertEquals(expectedModel.getFilteredEventList(), actualModel.getFilteredEventList());
+                FilteredList<Participant> expectedList =
+                        (FilteredList<Participant>) expectedModel.getFilteredParticipantList();
+                FilteredList<Participant> actualList =
+                        (FilteredList<Participant>) actualModel.getFilteredParticipantList();
+                for (int i = 0; i < expectedList.size(); i++) {
+                    assertTrue(expectedList.get(i).isSameParticipant(actualList.get(i)));
+                }
+            } else {
+                throw new AssertionError("assertEditCommandSuccess incorrectly called.");
+            }
+        } catch (CommandException ce) {
+            throw new AssertionError("Execution of command should not fail.", ce);
+        }
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/FilterEventCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FilterEventCommandTest.java
@@ -27,9 +27,9 @@ public class FilterEventCommandTest {
     @Test
     public void equals() {
         EventDateTimePredicate firstPredicate =
-                new EventDateTimePredicate(Collections.singletonList("2021-09-18"));
+                new EventDateTimePredicate(Collections.singletonList("2022-09-18"));
         EventDateTimePredicate secondPredicate =
-                new EventDateTimePredicate(Arrays.asList("2021-09-18", "1000"));
+                new EventDateTimePredicate(Arrays.asList("2022-09-18", "1000"));
 
         FilterEventCommand filterFirstCommand = new FilterEventCommand(firstPredicate);
         FilterEventCommand filterSecondCommand = new FilterEventCommand(secondPredicate);
@@ -55,7 +55,7 @@ public class FilterEventCommandTest {
     public void execute_onlyDateInput_multipleEventsFound() {
         String expectedMessage = String.format(MESSAGE_EVENTS_LISTED_OVERVIEW, 4);
         EventDateTimePredicate predicate =
-                new EventDateTimePredicate(Collections.singletonList("2021-09-18"));
+                new EventDateTimePredicate(Collections.singletonList("2022-09-18"));
         FilterEventCommand command = new FilterEventCommand(predicate);
         expectedModel.updateFilteredEventList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
@@ -66,7 +66,7 @@ public class FilterEventCommandTest {
     public void execute_dateAndTimeInput_oneEventFound() {
         String expectedMessage = String.format(MESSAGE_EVENTS_LISTED_OVERVIEW, 1);
         EventDateTimePredicate predicate =
-                new EventDateTimePredicate(Arrays.asList("2021-09-18", "1001"));
+                new EventDateTimePredicate(Arrays.asList("2022-09-18", "1001"));
         FilterEventCommand command = new FilterEventCommand(predicate);
         expectedModel.updateFilteredEventList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
@@ -88,7 +88,7 @@ public class FilterEventCommandTest {
     public void execute_dateAndTimeInput_noEventFound() {
         String expectedMessage = String.format(MESSAGE_EVENTS_LISTED_OVERVIEW, 0);
         EventDateTimePredicate predicate =
-                new EventDateTimePredicate(Arrays.asList("2021-09-18", "1020"));
+                new EventDateTimePredicate(Arrays.asList("2022-09-18", "1020"));
         FilterEventCommand command = new FilterEventCommand(predicate);
         expectedModel.updateFilteredEventList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);

--- a/src/test/java/seedu/address/logic/commands/FilterEventCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FilterEventCommandTest.java
@@ -27,9 +27,9 @@ public class FilterEventCommandTest {
     @Test
     public void equals() {
         EventDateTimePredicate firstPredicate =
-                new EventDateTimePredicate(Collections.singletonList("2022-09-18"));
+                new EventDateTimePredicate(Collections.singletonList("2021-09-18"));
         EventDateTimePredicate secondPredicate =
-                new EventDateTimePredicate(Arrays.asList("2022-09-18", "1000"));
+                new EventDateTimePredicate(Arrays.asList("2021-09-18", "1000"));
 
         FilterEventCommand filterFirstCommand = new FilterEventCommand(firstPredicate);
         FilterEventCommand filterSecondCommand = new FilterEventCommand(secondPredicate);
@@ -55,7 +55,7 @@ public class FilterEventCommandTest {
     public void execute_onlyDateInput_multipleEventsFound() {
         String expectedMessage = String.format(MESSAGE_EVENTS_LISTED_OVERVIEW, 4);
         EventDateTimePredicate predicate =
-                new EventDateTimePredicate(Collections.singletonList("2022-09-18"));
+                new EventDateTimePredicate(Collections.singletonList("2021-09-18"));
         FilterEventCommand command = new FilterEventCommand(predicate);
         expectedModel.updateFilteredEventList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
@@ -66,7 +66,7 @@ public class FilterEventCommandTest {
     public void execute_dateAndTimeInput_oneEventFound() {
         String expectedMessage = String.format(MESSAGE_EVENTS_LISTED_OVERVIEW, 1);
         EventDateTimePredicate predicate =
-                new EventDateTimePredicate(Arrays.asList("2022-09-18", "1001"));
+                new EventDateTimePredicate(Arrays.asList("2021-09-18", "1001"));
         FilterEventCommand command = new FilterEventCommand(predicate);
         expectedModel.updateFilteredEventList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
@@ -88,7 +88,7 @@ public class FilterEventCommandTest {
     public void execute_dateAndTimeInput_noEventFound() {
         String expectedMessage = String.format(MESSAGE_EVENTS_LISTED_OVERVIEW, 0);
         EventDateTimePredicate predicate =
-                new EventDateTimePredicate(Arrays.asList("2022-09-18", "1020"));
+                new EventDateTimePredicate(Arrays.asList("2021-09-18", "1020"));
         FilterEventCommand command = new FilterEventCommand(predicate);
         expectedModel.updateFilteredEventList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);

--- a/src/test/java/seedu/address/logic/parser/CommandParserTestUtil.java
+++ b/src/test/java/seedu/address/logic/parser/CommandParserTestUtil.java
@@ -1,7 +1,9 @@
 package seedu.address.logic.parser;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.address.logic.commands.AddCommand.isAddingSameParticipant;
 
+import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.parser.exceptions.ParseException;
 
@@ -17,7 +19,28 @@ public class CommandParserTestUtil {
     public static void assertParseSuccess(Parser parser, String userInput, Command expectedCommand) {
         try {
             Command command = parser.parse(userInput);
-            assertEquals(expectedCommand, command);
+            if (command instanceof AddCommand) {
+                assertParseSameParticipantSuccess(parser, userInput, expectedCommand);
+            } else {
+                assertEquals(expectedCommand, command);
+            }
+        } catch (ParseException pe) {
+            throw new IllegalArgumentException("Invalid userInput.", pe);
+        }
+    }
+
+    /**
+     * Asserts that the parsing of {@code userInput} by {@code parser} is successful and the command created
+     * equals to {@code expectedCommand}.
+     */
+    private static void assertParseSameParticipantSuccess(Parser parser, String userInput, Command expectedCommand) {
+        try {
+            Command command = parser.parse(userInput);
+            if (command instanceof AddCommand) {
+                isAddingSameParticipant(command, expectedCommand);
+            } else {
+                assertEquals(expectedCommand, command);
+            }
         } catch (ParseException pe) {
             throw new IllegalArgumentException("Invalid userInput.", pe);
         }

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -48,11 +48,8 @@ public class AddressBookTest {
 
     @Test
     public void resetData_withDuplicatePersons_throwsDuplicatePersonException() {
-        // Two persons with the same identity fields
-        Participant editedAlex = new ParticipantBuilder(ALEX).withAddress(VALID_ADDRESS_BOB).build();
-        List<Participant> newParticipants = Arrays.asList(ALEX, editedAlex);
+        List<Participant> newParticipants = Arrays.asList(ALEX, ALEX);
         AddressBookStub newData = new AddressBookStub(newParticipants);
-
         assertThrows(DuplicateParticipantException.class, () -> addressBook.resetData(newData));
     }
 
@@ -73,10 +70,10 @@ public class AddressBookTest {
     }
 
     @Test
-    public void hasPerson_personWithSameIdentityFieldsInAddressBook_returnsTrue() {
+    public void hasPerson_differentPersonSameIdentityFieldsInAddressBook_returnsFalse() {
         addressBook.addParticipant(ALEX);
         Participant editedAlex = new ParticipantBuilder(ALEX).withAddress(VALID_ADDRESS_BOB).build();
-        assertTrue(addressBook.hasParticipant(editedAlex));
+        assertFalse(addressBook.hasParticipant(editedAlex));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/participant/ParticipantTest.java
+++ b/src/test/java/seedu/address/model/participant/ParticipantTest.java
@@ -73,8 +73,8 @@ public class ParticipantTest {
         // same object -> returns true
         assertEquals(ALEX, ALEX);
 
-        // object copy -> returns true
-        assertEquals(alexCopy, ALEX);
+        // same details, different object -> returns false
+        assertNotEquals(alexCopy, ALEX);
 
         // null -> returns false
         assertNotEquals(ALEX, null);

--- a/src/test/java/seedu/address/storage/JsonSerializableAddressBookTest.java
+++ b/src/test/java/seedu/address/storage/JsonSerializableAddressBookTest.java
@@ -1,6 +1,7 @@
 package seedu.address.storage;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
 
 import java.nio.file.Path;
@@ -8,9 +9,11 @@ import java.nio.file.Paths;
 
 import org.junit.jupiter.api.Test;
 
+import javafx.collections.ObservableList;
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.commons.util.JsonUtil;
 import seedu.address.model.AddressBook;
+import seedu.address.model.participant.Participant;
 import seedu.address.testutil.TypicalEvents;
 import seedu.address.testutil.TypicalParticipants;
 
@@ -30,7 +33,12 @@ public class JsonSerializableAddressBookTest {
                 JsonSerializableAddressBook.class).get();
         AddressBook addressBookFromFile = dataFromFile.toModelType();
         AddressBook typicalPersonsAddressBook = TypicalParticipants.getTypicalAddressBook();
-        assertEquals(addressBookFromFile, typicalPersonsAddressBook);
+        assertEquals(addressBookFromFile.getEventList(), typicalPersonsAddressBook.getEventList());
+        ObservableList<Participant> fromFileList = addressBookFromFile.getParticipantList();
+        ObservableList<Participant> typicalList = typicalPersonsAddressBook.getParticipantList();
+        for (int i = 0; i < typicalList.size(); i++) {
+            assertTrue(fromFileList.get(i).isSameParticipant(typicalList.get(i)));
+        }
     }
 
     @Test

--- a/src/test/java/seedu/address/testutil/TypicalEvents.java
+++ b/src/test/java/seedu/address/testutil/TypicalEvents.java
@@ -1,5 +1,7 @@
 package seedu.address.testutil;
 
+import static seedu.address.testutil.TypicalParticipants.ALEX;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -10,46 +12,49 @@ import seedu.address.model.event.Event;
 import seedu.address.model.event.EventDate;
 import seedu.address.model.event.EventName;
 import seedu.address.model.event.EventTime;
+import seedu.address.model.participant.Participant;
 
 /**
  * An utility class containing a list of {@code Event} objects to be used in tests.
  */
 public class TypicalEvents {
-    public static final Event SAMPLE_EVENT = new Event(new EventName("Sleep"), new EventDate("2021-09-18"),
+    public static final Participant SAMPLE_PARTICIPANT = new ParticipantBuilder().build();
+
+    public static final Event SAMPLE_EVENT = new Event(new EventName("Sleep"), new EventDate("2022-09-18"),
             new EventTime("1000"));
-    public static final Event ANOTHER_EVENT = new Event(new EventName("Sleep2"), new EventDate("2021-09-18"),
+    public static final Event ANOTHER_EVENT = new Event(new EventName("Sleep2"), new EventDate("2022-09-18"),
             new EventTime("1001"));
     public static final Event SAMPLE_EVENT_2 = new Event(new EventName("Random Event 1"),
             new EventDate("1-1-1"), new EventTime("0001"));
-    public static final Event SAMPLE_EVENT_3 = new Event(new EventName("Sleep"), new EventDate("2021-09-18"),
+    public static final Event SAMPLE_EVENT_3 = new Event(new EventName("Sleep"), new EventDate("2022-09-18"),
             new EventTime("1002"), false, Collections.singletonList(new ParticipantBuilder().build()));
     public static final Event MARATHON_NO_TIME = new Event(new EventName("24km Marathon"),
-            new EventDate("2021-10-5"), new EventTime());
+            new EventDate("2022-10-5"), new EventTime());
     public static final Event MARATHON_HAS_TIME = new Event(new EventName("24Km Marathon with Time"),
-            new EventDate("2021-10-5"), new EventTime("0800"));
+            new EventDate("2022-10-5"), new EventTime("0800"));
     public static final Event CODE_FOR_SANITY = new Event(new EventName("Code For Sanity"),
-            new EventDate("2021-8-10"), new EventTime("0000"));
+            new EventDate("2022-8-10"), new EventTime("0000"));
     public static final Event SAMPLE_EVENT_SPECIFIED_TIME_AND_COMPLETION = new Event(new EventName("Sleep"),
-            new EventDate("2021-09-18"), new EventTime("1002"), true,
-            Collections.singletonList(new ParticipantBuilder().build()));
+            new EventDate("2022-09-18"), new EventTime("1002"), true,
+            Collections.singletonList(SAMPLE_PARTICIPANT));
     public static final Event SAMPLE_EVENT_SPECIFIED_TIME_AND_COMPLETION_COPY = new Event(new EventName("Sleep"),
-            new EventDate("2021-09-18"), new EventTime("1002"), true,
-            Collections.singletonList(new ParticipantBuilder().build()));
+            new EventDate("2022-09-18"), new EventTime("1002"), true,
+            Collections.singletonList(SAMPLE_PARTICIPANT));
     public static final Event SAMPLE_EVENT_DEFAULT_TIME_AND_COMPLETION = new Event(new EventName("Sleep again"),
-            new EventDate("2021-09-18"));
+            new EventDate("2022-09-18"));
     public static final Event SAMPLE_EVENT_COPY_DIFFERENT_NAME = new Event(new EventName("Sleeps"),
-            new EventDate("2021-09-18"), new EventTime("1000"));
+            new EventDate("2022-09-18"), new EventTime("1000"));
     public static final Event SAMPLE_EVENT_COPY_DIFFERENT_DATE = new Event(new EventName("Sleep"),
-            new EventDate("2021-09-19"), new EventTime("1000"));
+            new EventDate("2022-09-19"), new EventTime("1000"));
     public static final Event SAMPLE_EVENT_COPY_DIFFERENT_TIME = new Event(new EventName("Sleep"),
-            new EventDate("2021-09-18"), new EventTime("1001"));
+            new EventDate("2022-09-18"), new EventTime("1001"));
     public static final Event SAMPLE_EVENT_COPY_DIFFERENT_COMPLETION = new Event(new EventName("Sleep"),
-            new EventDate("2021-09-18"), new EventTime("1000"), true, new ArrayList<>());
+            new EventDate("2022-09-18"), new EventTime("1000"), true, new ArrayList<>());
     public static final Event SAMPLE_EVENT_COPY_DIFFERENT_PARTICIPANTS = new Event(new EventName("Sleep"),
-            new EventDate("2021-09-18"), new EventTime("1000"), false,
-            Collections.singletonList(new ParticipantBuilder().build()));
+            new EventDate("2022-09-18"), new EventTime("1000"), false,
+            Collections.singletonList(ALEX));
     public static final Event SAMPLE_EVENT_COPY_NO_TIME = new Event(new EventName("Slept"),
-            new EventDate("2021-09-18"));
+            new EventDate("2022-09-18"));
 
     private TypicalEvents() {}
 

--- a/src/test/java/seedu/address/testutil/TypicalEvents.java
+++ b/src/test/java/seedu/address/testutil/TypicalEvents.java
@@ -20,41 +20,41 @@ import seedu.address.model.participant.Participant;
 public class TypicalEvents {
     public static final Participant SAMPLE_PARTICIPANT = new ParticipantBuilder().build();
 
-    public static final Event SAMPLE_EVENT = new Event(new EventName("Sleep"), new EventDate("2022-09-18"),
+    public static final Event SAMPLE_EVENT = new Event(new EventName("Sleep"), new EventDate("2021-09-18"),
             new EventTime("1000"));
-    public static final Event ANOTHER_EVENT = new Event(new EventName("Sleep2"), new EventDate("2022-09-18"),
+    public static final Event ANOTHER_EVENT = new Event(new EventName("Sleep2"), new EventDate("2021-09-18"),
             new EventTime("1001"));
     public static final Event SAMPLE_EVENT_2 = new Event(new EventName("Random Event 1"),
             new EventDate("1-1-1"), new EventTime("0001"));
-    public static final Event SAMPLE_EVENT_3 = new Event(new EventName("Sleep"), new EventDate("2022-09-18"),
+    public static final Event SAMPLE_EVENT_3 = new Event(new EventName("Sleep"), new EventDate("2021-09-18"),
             new EventTime("1002"), false, Collections.singletonList(new ParticipantBuilder().build()));
     public static final Event MARATHON_NO_TIME = new Event(new EventName("24km Marathon"),
-            new EventDate("2022-10-5"), new EventTime());
+            new EventDate("2021-10-5"), new EventTime());
     public static final Event MARATHON_HAS_TIME = new Event(new EventName("24Km Marathon with Time"),
-            new EventDate("2022-10-5"), new EventTime("0800"));
+            new EventDate("2021-10-5"), new EventTime("0800"));
     public static final Event CODE_FOR_SANITY = new Event(new EventName("Code For Sanity"),
-            new EventDate("2022-8-10"), new EventTime("0000"));
+            new EventDate("2021-8-10"), new EventTime("0000"));
     public static final Event SAMPLE_EVENT_SPECIFIED_TIME_AND_COMPLETION = new Event(new EventName("Sleep"),
-            new EventDate("2022-09-18"), new EventTime("1002"), true,
+            new EventDate("2021-09-18"), new EventTime("1002"), true,
             Collections.singletonList(SAMPLE_PARTICIPANT));
     public static final Event SAMPLE_EVENT_SPECIFIED_TIME_AND_COMPLETION_COPY = new Event(new EventName("Sleep"),
-            new EventDate("2022-09-18"), new EventTime("1002"), true,
+            new EventDate("2021-09-18"), new EventTime("1002"), true,
             Collections.singletonList(SAMPLE_PARTICIPANT));
     public static final Event SAMPLE_EVENT_DEFAULT_TIME_AND_COMPLETION = new Event(new EventName("Sleep again"),
-            new EventDate("2022-09-18"));
+            new EventDate("2021-09-18"));
     public static final Event SAMPLE_EVENT_COPY_DIFFERENT_NAME = new Event(new EventName("Sleeps"),
-            new EventDate("2022-09-18"), new EventTime("1000"));
+            new EventDate("2021-09-18"), new EventTime("1000"));
     public static final Event SAMPLE_EVENT_COPY_DIFFERENT_DATE = new Event(new EventName("Sleep"),
-            new EventDate("2022-09-19"), new EventTime("1000"));
+            new EventDate("2021-09-19"), new EventTime("1000"));
     public static final Event SAMPLE_EVENT_COPY_DIFFERENT_TIME = new Event(new EventName("Sleep"),
-            new EventDate("2022-09-18"), new EventTime("1001"));
+            new EventDate("2021-09-18"), new EventTime("1001"));
     public static final Event SAMPLE_EVENT_COPY_DIFFERENT_COMPLETION = new Event(new EventName("Sleep"),
-            new EventDate("2022-09-18"), new EventTime("1000"), true, new ArrayList<>());
+            new EventDate("2021-09-18"), new EventTime("1000"), true, new ArrayList<>());
     public static final Event SAMPLE_EVENT_COPY_DIFFERENT_PARTICIPANTS = new Event(new EventName("Sleep"),
-            new EventDate("2022-09-18"), new EventTime("1000"), false,
+            new EventDate("2021-09-18"), new EventTime("1000"), false,
             Collections.singletonList(ALEX));
     public static final Event SAMPLE_EVENT_COPY_NO_TIME = new Event(new EventName("Slept"),
-            new EventDate("2022-09-18"));
+            new EventDate("2021-09-18"));
 
     private TypicalEvents() {}
 

--- a/src/test/java/seedu/address/testutil/TypicalEvents.java
+++ b/src/test/java/seedu/address/testutil/TypicalEvents.java
@@ -1,7 +1,5 @@
 package seedu.address.testutil;
 
-import static seedu.address.testutil.TypicalParticipants.ALEX;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -52,7 +50,7 @@ public class TypicalEvents {
             new EventDate("2021-09-18"), new EventTime("1000"), true, new ArrayList<>());
     public static final Event SAMPLE_EVENT_COPY_DIFFERENT_PARTICIPANTS = new Event(new EventName("Sleep"),
             new EventDate("2021-09-18"), new EventTime("1000"), false,
-            Collections.singletonList(ALEX));
+            Collections.singletonList(SAMPLE_PARTICIPANT));
     public static final Event SAMPLE_EVENT_COPY_NO_TIME = new Event(new EventName("Slept"),
             new EventDate("2021-09-18"));
 


### PR DESCRIPTION
Changes made:
- isSameParticipant method in Participant checks if two Participant objects have all the same details excluding ID
- equals method in Participant checks if two Participant objects have all the same details including ID
- Update test cases to follow the new definitions

Ultimately this does allow for the adding of Participants with the same name, and will extend all the way to allowing Participants with all identical details except for one.

This change complicates testing a fair bit, since some tests require creating two separate Participant objects and comparing them: we can no longer use assertEquals(participant1, participant2) since this will return false due to different IDs, we have to use isSameParticipant instead.

This gets especially complicated when we have things like assertEquals(model, expectedModel), because essentially I have to break down the models into userPrefs, filteredParticipants and filteredEvents, then I assertEquals the two userPrefs and two filteredEvents, and the two filteredParticipants I use a for loop to do assertTrue(participant1.isSameParticipant(participant2)).

Fortunately these issues only seem to happen for AddCommand and EditCommand so if you're wondering why I have some `if command instanceof AddCommand` or `EditCommand` it's because I created new methods specifically to deal with these.

Likely not the best method of dealing with it, lmk if there are easier ways.